### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # AI-DM-Helper
-This is an AI to help DMs retrieve data for there campaign and enhance it with descriptions from open AI CC BY-NC-SA
+This is an AI to help DMs retrieve data for their campaign and enhance it with descriptions from open AI CC BY-NC-SA


### PR DESCRIPTION
Iterated over README.md text in order to find and handle unintended misspellings of English language words. This yielded a single typo: "there" was used instead of "their". This error causes semantic difference in interpretation of the README.md text which can cause user confusion and agony.